### PR TITLE
cleanup and simplify the Bologna

### DIFF
--- a/src/neuroboros/datasets/__init__.py
+++ b/src/neuroboros/datasets/__init__.py
@@ -461,9 +461,7 @@ class Bologna(Dataset):
         prep="default",
         fp_version="25.2.5",
         name="bologna",
-        root_dir="/dartfs/rc/lab/H/HaxbyLab/yuqi/Bellaria_new/fmriprep_25.2.5_resampled_all",
-        confounds_dir="/dartfs/rc/lab/H/HaxbyLab/feilong/nb-data/bologna117/25.2.5/confounds",
-        subject_sets_dir="/dartfs/rc/lab/H/HaxbyLab/feilong/nb-data/bologna117/subject_sets",
+        root_dir="/dartfs/rc/lab/H/HaxbyLab/feilong/nb-data/bologna117",
         dl_source=None,
     ):
         super().__init__(
@@ -475,45 +473,12 @@ class Bologna(Dataset):
             prep=prep,
             fp_version=fp_version,
         )
-        self.confounds_dm = DatasetManager(name, root=confounds_dir, source=None)
-        for fn in sorted(glob(os.path.join(subject_sets_dir, "*.txt"))):
-            group = os.path.basename(fn)[:-4]
-            with open(fn) as f:
-                self.subject_sets[group] = f.read().splitlines()
         self.subjects = self.subject_sets["all"]
         self.tasks = ["rest"]
 
     def rename_func(self, sid, task, run, suffix=".npy"):
         basename = f"sub-{sid}_task-{task}{suffix}"
         return basename
-
-    def load_data(self, sid, task, run, lr, space, resample, fp_version=None):
-        if lr == "lr":
-            return np.concatenate(
-                [
-                    self.load_data(sid, task, run, lr_, space, resample, fp_version)
-                    for lr_ in "lr"
-                ],
-                axis=1,
-            )
-        if lr in ["l", "r"]:
-            lr = f"{lr}-cerebrum"
-        fn = ["resampled", space, lr, resample, self.rename_func(sid, task, run)]
-        dm = self.dl_dset.get(fn, on_missing="raise").astype(np.float64)
-        return dm
-
-    def load_confounds(self, sid, task, run, fp_version=None):
-        suffix_li = [
-            "desc-confounds_timeseries.npy",
-            "desc-confounds_timeseries.tsv",
-            "desc-mask_timeseries.npy",
-        ]
-        return [
-            self.confounds_dm.get(
-                self.rename_func(sid, task, run, "_" + suffix), on_missing="raise"
-            )
-            for suffix in suffix_li
-        ]
 
 class Bellaria(Dataset):
     def __init__(

--- a/src/neuroboros/datasets/__init__.py
+++ b/src/neuroboros/datasets/__init__.py
@@ -463,7 +463,7 @@ class Bologna(Dataset):
         name="bologna",
         root_dir="/dartfs/rc/lab/H/HaxbyLab/yuqi/Bellaria_new/fmriprep_25.2.5_resampled_all",
         confounds_dir="/dartfs/rc/lab/H/HaxbyLab/feilong/nb-data/bologna117/25.2.5/confounds",
-        subjects_fn="/dartfs/rc/lab/H/HaxbyLab/feilong/nb-data/bologna117/subject_sets/all.txt",
+        subject_sets_dir="/dartfs/rc/lab/H/HaxbyLab/feilong/nb-data/bologna117/subject_sets",
         dl_source=None,
     ):
         super().__init__(
@@ -476,8 +476,14 @@ class Bologna(Dataset):
             fp_version=fp_version,
         )
         self.confounds_dm = DatasetManager(name, root=confounds_dir, source=None)
-        with open(subjects_fn) as f:
-            self.subjects = f.read().splitlines()
+        # Unlike other datasets, subject sets (all/AD/HC/MCI/SCD) live in a
+        # separate tree, not under `root_dir`, so populate them here instead
+        # of relying on the auto-scan in Dataset.__init__.
+        for fn in sorted(glob(os.path.join(subject_sets_dir, "*.txt"))):
+            group = os.path.basename(fn)[:-4]
+            with open(fn) as f:
+                self.subject_sets[group] = f.read().splitlines()
+        self.subjects = self.subject_sets["all"]
         self.tasks = ["rest"]
 
     def rename_func(self, sid, task, run, suffix=".npy"):

--- a/src/neuroboros/datasets/__init__.py
+++ b/src/neuroboros/datasets/__init__.py
@@ -476,9 +476,6 @@ class Bologna(Dataset):
             fp_version=fp_version,
         )
         self.confounds_dm = DatasetManager(name, root=confounds_dir, source=None)
-        # Unlike other datasets, subject sets (all/AD/HC/MCI/SCD) live in a
-        # separate tree, not under `root_dir`, so populate them here instead
-        # of relying on the auto-scan in Dataset.__init__.
         for fn in sorted(glob(os.path.join(subject_sets_dir, "*.txt"))):
             group = os.path.basename(fn)[:-4]
             with open(fn) as f:


### PR DESCRIPTION
>>> import neuroboros as nb
/dartfs-hpc/rc/home/q/f007d9q/neuroboros/src/neuroboros/io.py:60: UserWarning: DataLad dataset core exists at /dartfs-hpc/rc/home/q/f007d9q/.neuroboros-data/core, but does not have source https://gin.g-node.org/neuroboros/core as a sibling.
  warnings.warn(
>>> ds = nb.Bologna()
>>> ds.subject_sets['AD']
['01898', '13295', '22897', '24240', '25410', '25425', '29188', '29859', '39407', '42589', '45129', '61052', '66386', '67909', '75366', '84322', '91177', '93054', '95185', '97072']
>>> sid = ds.subjects[0]
>>> dm = ds.get_data(sid, 'rest', 0, 'lr', space='onavg-ico32', resample='1step_pial_overlap')
>>> dm
array([[ 1.0348552 ,  0.35150871,  2.37630427, ..., -0.57055143,
         8.39766113,  1.39647484],
       [ 1.5548565 , -0.08434479,  2.10199604, ...,  0.11769141,
         6.55742291,  1.56371697],
       [ 1.49630594, -0.26346185,  0.16134075, ...,  1.09686573,
         3.0364949 ,  0.3218081 ],
       ...,
       [-2.46775967,  2.27561905,  0.74240477, ..., -0.07685096,
        -0.10985547,  0.58652709],
       [-1.70545952, -0.3383896 , -0.6849789 , ..., -0.6955783 ,
         0.27878608, -0.5160106 ],
       [-0.56335565,  0.7378668 , -0.273147  , ...,  1.37758691,
         0.35073525,  0.56461115]], shape=(816, 19341))